### PR TITLE
[ZEPPELIN-5942] Adds a null check to the argument recoveryStorage

### DIFF
--- a/zeppelin-interpreter/src/main/java/org/apache/zeppelin/interpreter/launcher/InterpreterLauncher.java
+++ b/zeppelin-interpreter/src/main/java/org/apache/zeppelin/interpreter/launcher/InterpreterLauncher.java
@@ -41,6 +41,9 @@ public abstract class InterpreterLauncher {
   protected InterpreterLauncher(ZeppelinConfiguration zConf, RecoveryStorage recoveryStorage) {
     this.zConf = zConf;
     this.recoveryStorage = recoveryStorage;
+    if (zConf.isRecoveryEnabled() && recoveryStorage == null) {
+      throw new IllegalArgumentException("recoveryStorage must not be null when zeppelin.recovery.storage.class is set");
+    }
   }
 
   /**


### PR DESCRIPTION
### What is this PR for?

This PR adds a null to the argument `recoveryStorage` in the constructor of `InterpreterLauncher`. Specifically, if the argument is null when `zeppelin.recovery.storage.class` is not `org.apache.zeppelin.interpreter.recovery.NullRecoveryStorage`, an `IllegalArgumentException` will be thrown.

### What type of PR is it?

Bug Fix

### What is the Jira issue?

* https://issues.apache.org/jira/browse/ZEPPELIN-5942

### How should this be tested?

(1) Set `zeppelin.recovery.storage.class` to `org.apache.zeppelin.interpreter.recovery.FileSystemRecoveryStorage `
(2) Run test: `org.apache.zeppelin.interpreter.launcher.StandardInterpreterLauncherTest#testLauncher`
The test will lead to an `IllegalArgumentException`, instead of a `NullPointerException` without any message.

### Questions:

* Does the license files need to update? No
* Is there breaking changes for older versions? No
* Does this needs documentation? Yes. 